### PR TITLE
refactor: move content validations to functions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: "Maximum value of percentage match (0-1) between body and template before the action fails"
     default: "0.7"
 outputs:
-  myOutput:
-    description: "Output from the action"
+  pull_request_body_match:
+    description: "Output to indicate the similarity with the pull request template (score between 0-1)"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/main.py
+++ b/main.py
@@ -25,7 +25,8 @@ def is_pr_body_below_similarity_score(pr_body,
         None,
         pr_body,
         pr_template_contents).ratio()
-    set_github_action_output('myOutput', pr_body_similarity_score)
+    set_github_action_output('pull_request_body_match',
+                             pr_body_similarity_score)
     if pr_body_similarity_score > max_pull_request_similarity_score:
         print(
             f"{pr_body_similarity_score} exceeds max similarity score"
@@ -55,8 +56,6 @@ def main():
     pr_body = event_data["pull_request"]["body"].strip()
     pr_title = event_data["pull_request"]["title"].strip()
 
-    is_pr_body_empty(pr_body)
-
     pr_filestream = open(pr_template_path)
     pr_template_contents = pr_filestream.read().strip()
     pr_filestream.close()
@@ -65,6 +64,7 @@ def main():
     pr_title = event_data["pull_request"]["title"].strip()
     print(pr_body)
     print(pr_title)
+    is_pr_body_empty(pr_body)
     is_pr_body_below_similarity_score(pr_body,
                                       pr_template_contents,
                                       max_pull_request_description_match)


### PR DESCRIPTION
Move pull request content validations to separate functions for comparing the body with template contents and checking if body is empty. Throw exception if either of these validations fail